### PR TITLE
Added Image loading & processing python script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dataset
 # IDE
 .idea
+connect.sh

--- a/requirements.in
+++ b/requirements.in
@@ -8,3 +8,4 @@ pandas==0.20.3
 matplotlib==2.0.2
 
 pip-tools==1.9.0
+Pillow==4.2.1

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 # Core
 tensorflow==1.3.0
 mxnet==0.11.0
+boto3==1.4.7
 
 # Data tool
 numpy==1.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,9 @@ markdown==2.6.9           # via tensorflow-tensorboard
 matplotlib==2.0.2
 mxnet==0.11.0
 numpy==1.13.1
+olefile==0.44             # via pillow
 pandas==0.20.3
+pillow==4.2.1
 pip-tools==1.9.0
 protobuf==3.4.0           # via tensorflow, tensorflow-tensorboard
 pyparsing==2.2.0          # via matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,15 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 bleach==1.5.0             # via tensorflow-tensorboard
+boto3==1.4.7
+botocore==1.7.16          # via boto3, s3transfer
 click==6.7                # via pip-tools
 cycler==0.10.0            # via matplotlib
+docutils==0.14            # via botocore
 first==2.0.1              # via pip-tools
 graphviz==0.8             # via mxnet
 html5lib==0.9999999       # via bleach, tensorflow-tensorboard
+jmespath==0.9.3           # via boto3, botocore
 markdown==2.6.9           # via tensorflow-tensorboard
 matplotlib==2.0.2
 mxnet==0.11.0
@@ -20,8 +24,9 @@ pillow==4.2.1
 pip-tools==1.9.0
 protobuf==3.4.0           # via tensorflow, tensorflow-tensorboard
 pyparsing==2.2.0          # via matplotlib
-python-dateutil==2.6.1    # via matplotlib, pandas
+python-dateutil==2.6.1    # via botocore, matplotlib, pandas
 pytz==2017.2              # via matplotlib, pandas
+s3transfer==0.1.11        # via boto3
 six==1.10.0               # via bleach, cycler, html5lib, matplotlib, pip-tools, protobuf, python-dateutil, tensorflow, tensorflow-tensorboard
 tensorflow-tensorboard==0.1.6  # via tensorflow
 tensorflow==1.3.0

--- a/src/load_and_process_images.py
+++ b/src/load_and_process_images.py
@@ -1,0 +1,39 @@
+import glob
+import os
+
+import boto3
+from PIL import Image
+
+IMAGE_DIR = "dataset/bin-images/"
+IMAGE_SIZE = 224
+TOTAL_IMAGES = 535234
+
+def connect_s3_bucket():
+    s3 = boto3.resource('s3', region_name='us-east-1')
+    bucket = s3.Bucket(name='aft-vbi-pds')
+    return bucket
+
+
+def process_image(image_file):
+    image = Image.open(image_file).convert('RGB')
+    resized_image = image.resize((IMAGE_SIZE, IMAGE_SIZE), Image.LINEAR)
+    resized_image.save(image_file)
+
+
+if __name__ == '__main__':
+    if not os.path.exists(IMAGE_DIR):
+        print('mkdir ' + IMAGE_DIR)
+        os.makedirs(IMAGE_DIR)
+    start = len(glob.glob(IMAGE_DIR + '/*.jpg')) if len(glob.glob(IMAGE_DIR + '/*.jpg')) > 0 else 1
+    print('Start from %05d.jpg' % start)
+    bucket = connect_s3_bucket()
+    N = 535234
+    for i in range(start, N+1):
+        filename = '%05d.jpg' % i
+        source = 'bin-images/' + filename
+        dest = IMAGE_DIR + filename
+        bucket.download_file(source, dest)
+        process_image(dest)
+        print('Processed {0}({1}/{2})'.format(dest, i, N))
+
+    print('Processing Done')


### PR DESCRIPTION
- boto3 을 이용해 S3 bucket 에서 이미지를 다운받아서 임시로 저장
- Pillow image processing library 를 이용해 S3에서 받아온 이미지를 224*224 사이즈로 변환해서 최종 저장

전체를 다 돌려보진 않았지만 로컬에서 2000개 정도의 데이터로 진행했을때 그냥 저장하는것보다 평균 1/8 정도 줄어든 것을 확인했습니다. 그정도 사이즈면 서버에서 들고있기 무리가 없을 것으로 보입니다. 
리뷰 완료되면 서버에서 돌려서 우선 전체 데이터를 받아두도록 하겠습니다.